### PR TITLE
Use double qoutes in lib/omniauth/strategies/qualtrics.rb

### DIFF
--- a/lib/omniauth/strategies/qualtrics.rb
+++ b/lib/omniauth/strategies/qualtrics.rb
@@ -1,14 +1,14 @@
-require 'omniauth-oauth2'
+require "omniauth-oauth2"
 
 module OmniAuth
   module Strategies
     class Qualtrics < OmniAuth::Strategies::OAuth2
-      option :name, 'qualtrics'
+      option :name, "qualtrics"
 
       option :client_options,
-             site: 'https://co1.qualtrics.com',
-             authorize_url: '/oauth2/auth',
-             token_url: '/oauth2/token'
+        site: "https://co1.qualtrics.com",
+        authorize_url: "/oauth2/auth",
+        token_url: "/oauth2/token"
 
       # Qualtrics does use state but we want to control it rather than letting
       # omniauth-oauth2 handle it.
@@ -18,7 +18,7 @@ module OmniAuth
 
       info do
         {
-          'url' => access_token.client.site
+          "url" => access_token.client.site
         }
       end
 
@@ -32,11 +32,11 @@ module OmniAuth
       def authorize_params
         # Only set state if it hasn't already been set
         options.authorize_params[:state] ||= SecureRandom.hex(24)
-        options.authorize_params[:scope] = 'manage:all'
-        params = options.authorize_params.merge(options_for('authorize'))
+        options.authorize_params[:scope] = "manage:all"
+        params = options.authorize_params.merge(options_for("authorize"))
         if OmniAuth.config.test_mode
           @env ||= {}
-          @env['rack.session'] ||= {}
+          @env["rack.session"] ||= {}
         end
         params
       end
@@ -44,5 +44,5 @@ module OmniAuth
   end
 end
 
-OmniAuth.config.add_camelization 'qualtrics', 'Qualtrics'
+OmniAuth.config.add_camelization "qualtrics", "Qualtrics"
 


### PR DESCRIPTION
Per maintainer request https://github.com/atomicjolt/omniauth-qualtrics/pull/1#pullrequestreview-2222304496, he would like us to use `""` instead of `''` to be consistent with the rest of a project before merging our fix